### PR TITLE
fix : 네비게이션 로직 수정

### DIFF
--- a/DeuCapStone2023/app/build.gradle
+++ b/DeuCapStone2023/app/build.gradle
@@ -120,11 +120,14 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation "com.squareup.okhttp3:logging-interceptor:4.9.3"
     implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
+
+    // locationService
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
 }
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.14.0"
+        artifact = "com.google.protobuf:protoc:3.18.0"
     }
 
     generateProtoTasks {

--- a/DeuCapStone2023/app/src/main/AndroidManifest.xml
+++ b/DeuCapStone2023/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DeuCapStone2023"
+        android:screenOrientation="portrait"
         tools:targetApi="31">
 
         <activity

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/data/dto/request/RouteRequest.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/data/dto/request/RouteRequest.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class RouteRequest(
     @SerializedName("startX") val startLongitude: Double,
-    @SerializedName("startY") val startLatitude: Double ,
+    @SerializedName("startY") val startLatitude: Double,
     @SerializedName("endPoiId") val destinationPoiId: String,
     @SerializedName("endX") val destinationLongitude: Double,
     @SerializedName("endY") val destinationLatitude: Double,

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/data/mapper/Mapper.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/data/mapper/Mapper.kt
@@ -6,6 +6,7 @@ import com.example.deucapstone2023.data.dto.response.poi.RouteResponse
 import com.example.deucapstone2023.domain.model.LineModel
 import com.example.deucapstone2023.domain.model.POIModel
 import com.example.deucapstone2023.domain.model.RouteModel
+import com.skt.tmap.MapUtils
 
 fun POIModel.toRequestDTO(appKey: String) = mutableMapOf<String, String>().apply {
     put("version", "1")
@@ -114,7 +115,7 @@ fun RouteResponse.toRouteModel() = this.run {
                 destinationLongitude = (((location?.last() ?: .0) as List<*>?)?.get(0) ?: .0) as Double
                 routeName = feature.properties?.name ?: ""
                 routeFacilityType = if (feature.properties?.facilityType?.isNotBlank() == true) feature.properties.facilityType.toInt() ?: 0 else 0
-                totalDistance = feature.properties?.distance ?: 0
+                totalDistance = feature.properties?.distance ?: MapUtils.getDistance(startLatitude, startLongitude, destinationLatitude, destinationLongitude).toInt()
                 totalTime = feature.properties?.time ?: 0
                 lineInfo.addAll(location?.map {
                     val eachLocation = (it as List<*>)

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/domain/model/di/UsecaseModule.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/domain/model/di/UsecaseModule.kt
@@ -1,4 +1,4 @@
-package com.example.deucapstone2023.domain.di
+package com.example.deucapstone2023.domain.model.di
 
 import com.example.deucapstone2023.domain.usecase.POIUsecase
 import com.example.deucapstone2023.domain.usecase.RouteUsecase

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/base/AzimuthType.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/base/AzimuthType.kt
@@ -11,8 +11,8 @@ enum class AzimuthType {
 
 fun getAzimuthFromValue(azimuth: Double) =
     when(azimuth.roundToInt()) {
-        in 46..135 -> AzimuthType.NORTH
-        in 136..225 -> AzimuthType.EAST
-        in 226..315 -> AzimuthType.SOUTH
-        else -> AzimuthType.WEST
+        in 46..135 -> AzimuthType.EAST
+        in 136..225 -> AzimuthType.SOUTH
+        in 226..315 -> AzimuthType.WEST
+        else -> AzimuthType.NORTH
     }

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/base/AzimuthType.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/base/AzimuthType.kt
@@ -1,0 +1,18 @@
+package com.example.deucapstone2023.ui.base
+
+import kotlin.math.roundToInt
+
+enum class AzimuthType {
+    NORTH,
+    SOUTH,
+    WEST,
+    EAST;
+}
+
+fun getAzimuthFromValue(azimuth: Double) =
+    when(azimuth.roundToInt()) {
+        in 46..135 -> AzimuthType.NORTH
+        in 136..225 -> AzimuthType.EAST
+        in 226..315 -> AzimuthType.SOUTH
+        else -> AzimuthType.WEST
+    }

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/base/TurnType.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/base/TurnType.kt
@@ -40,3 +40,35 @@ enum class TurnType(val code: Int, val desc: String) {
         fun getType(code: Int) = TurnType.values().first { it.code == code }
     }
 }
+
+fun TurnType.toAzimuthType(currentAzimuth: AzimuthType) =
+    when(currentAzimuth) {
+        AzimuthType.NORTH -> {
+            when(this) {
+                TurnType.TURN_LEFT, TurnType.TURN_LEFT_10, TurnType.TURN_LEFT_8, TurnType.LEFT_CROSSWALK -> AzimuthType.WEST
+                TurnType.RIGHT_CROSSWALK,TurnType.TURN_RIGHT,TurnType.TURN_RIGHT_2,TurnType.TURN_RIGHT_4 -> AzimuthType.EAST
+                else -> currentAzimuth
+            }
+        }
+        AzimuthType.SOUTH -> {
+            when(this) {
+                TurnType.TURN_LEFT, TurnType.TURN_LEFT_10, TurnType.TURN_LEFT_8, TurnType.LEFT_CROSSWALK -> AzimuthType.EAST
+                TurnType.RIGHT_CROSSWALK,TurnType.TURN_RIGHT,TurnType.TURN_RIGHT_2,TurnType.TURN_RIGHT_4 -> AzimuthType.WEST
+                else -> currentAzimuth
+            }
+        }
+        AzimuthType.EAST -> {
+            when(this) {
+                TurnType.TURN_LEFT, TurnType.TURN_LEFT_10, TurnType.TURN_LEFT_8, TurnType.LEFT_CROSSWALK -> AzimuthType.NORTH
+                TurnType.RIGHT_CROSSWALK,TurnType.TURN_RIGHT,TurnType.TURN_RIGHT_2,TurnType.TURN_RIGHT_4 -> AzimuthType.SOUTH
+                else -> currentAzimuth
+            }
+        }
+        AzimuthType.WEST -> {
+            when(this) {
+                TurnType.TURN_LEFT, TurnType.TURN_LEFT_10, TurnType.TURN_LEFT_8, TurnType.LEFT_CROSSWALK -> AzimuthType.SOUTH
+                TurnType.RIGHT_CROSSWALK,TurnType.TURN_RIGHT,TurnType.TURN_RIGHT_2,TurnType.TURN_RIGHT_4 -> AzimuthType.NORTH
+                else -> currentAzimuth
+            }
+        }
+    }

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/di/NavigationManagerModule.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/di/NavigationManagerModule.kt
@@ -1,0 +1,27 @@
+package com.example.deucapstone2023.ui.di
+
+import com.example.deucapstone2023.ui.screen.search.state.NavigationManager
+import com.example.deucapstone2023.ui.screen.search.state.NavigationManagerImpl
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object NavigationManagerModule {
+
+    @Provides
+    fun providesNavigationManager(): NavigationManagerImpl {
+        return NavigationManagerImpl()
+    }
+
+}
+
+@Module
+@InstallIn(ViewModelComponent::class)
+abstract class BindingNavigationModule {
+    @Binds
+    abstract fun bindsNavigationManager(navigationManagerImpl: NavigationManagerImpl) : NavigationManager
+}

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
@@ -143,8 +143,8 @@ class MainActivity : ComponentActivity() {
         }
 
         tMapGpsManager = TMapGpsManager(this).apply {
-            minTime = 7000
-            minDistance = 4.5F
+            minTime = 6000
+            minDistance = 4F
             provider = TMapGpsManager.PROVIDER_GPS
             setOnLocationChangeListener { location ->
                 searchViewModel::setUserLocation.invoke(location.latitude, location.longitude)

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
@@ -112,17 +112,25 @@ class MainActivity : ComponentActivity() {
         /*lifecycleScope.launch {
             var searchUiState = com.example.deucapstone2023.ui.screen.search.state.Location.getInitValues()
             var flag = false
+            var flag2 = false
             launch {
                 searchViewModel.searchUiState.collect { state->
                     searchUiState = state.location
+
                     if(searchUiState.latitude != 0.0)
                         flag = true
+                    if(searchViewModel.navigationManager.routeIndex == 1)
+                        flag2 = true
                 }
             }
             launch {
                 while(true) {
                     while (flag) {
-                        searchViewModel::setUserLocation.invoke(searchUiState.latitude +0.00005000000000 , searchUiState.longitude - 0.00000500000000 )
+                        if(!flag2)
+                            searchViewModel::setUserLocation.invoke(searchUiState.latitude +0.00010000000000 , searchUiState.longitude - 0.00001000000000 )
+                        else
+                            searchViewModel::setUserLocation.invoke(searchUiState.latitude + 0.00000050000000 , searchUiState.longitude - 0.0001000000000 )
+                        Log.d("test",flag2.toString())
                         delay(5000)
                     }
                     delay(1000)

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
@@ -144,7 +144,7 @@ class MainActivity : ComponentActivity() {
 
         tMapGpsManager = TMapGpsManager(this).apply {
             minTime = 6000
-            minDistance = 4F
+            minDistance = 3.5F
             provider = TMapGpsManager.PROVIDER_GPS
             setOnLocationChangeListener { location ->
                 searchViewModel::setUserLocation.invoke(location.latitude, location.longitude)

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
@@ -10,11 +10,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.location.Location
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
-import android.media.AudioManager.OnAudioFocusChangeListener
 import android.os.Bundle
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
@@ -32,7 +30,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -42,12 +39,10 @@ import androidx.lifecycle.withStarted
 import androidx.navigation.compose.rememberNavController
 import com.example.deucapstone2023.R
 import com.example.deucapstone2023.ui.base.CommonRecognitionListener
-import com.example.deucapstone2023.ui.screen.search.SearchUiState
 import com.example.deucapstone2023.ui.screen.search.SearchViewModel
 import com.example.deucapstone2023.ui.screen.setting.SettingViewModel
 import com.example.deucapstone2023.ui.screen.setting.state.ButtonStatus
 import com.example.deucapstone2023.ui.screen.setting.state.toBoolean
-import com.example.deucapstone2023.ui.service.SpeechService
 import com.example.deucapstone2023.ui.theme.DeuCapStone2023Theme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -329,7 +324,7 @@ class MainActivity : ComponentActivity() {
 
     private fun readOnBluetooth() {
         bluetoothSocket?.let { socket ->
-            socket.inputStream.read(ByteArray(4096))
+            socket.inputStream.read(byteArrayOf())
         }
     }
 

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/navigation/MainActivity.kt
@@ -10,7 +10,11 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.pm.PackageManager
+import android.location.Location
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.media.AudioManager.OnAudioFocusChangeListener
 import android.os.Bundle
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
@@ -28,35 +32,33 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.core.app.ActivityCompat
+import androidx.compose.ui.focus.FocusRequester
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.lifecycle.withCreated
 import androidx.lifecycle.withStarted
 import androidx.navigation.compose.rememberNavController
 import com.example.deucapstone2023.R
 import com.example.deucapstone2023.ui.base.CommonRecognitionListener
-import com.example.deucapstone2023.ui.screen.search.SearchEventFlow
+import com.example.deucapstone2023.ui.screen.search.SearchUiState
 import com.example.deucapstone2023.ui.screen.search.SearchViewModel
 import com.example.deucapstone2023.ui.screen.setting.SettingViewModel
 import com.example.deucapstone2023.ui.screen.setting.state.ButtonStatus
-import com.example.deucapstone2023.ui.screen.setting.state.getButtonStatus
 import com.example.deucapstone2023.ui.screen.setting.state.toBoolean
 import com.example.deucapstone2023.ui.service.SpeechService
 import com.example.deucapstone2023.ui.theme.DeuCapStone2023Theme
-import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.util.Locale
 import java.util.UUID
+
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -70,6 +72,22 @@ class MainActivity : ComponentActivity() {
     private var bluetoothSocket: BluetoothSocket? = null
     private lateinit var bluetoothReceiver: BroadcastReceiver
     private var deviceHasFoundedFlag = false
+    private val audioManager by lazy { getSystemService(Context.AUDIO_SERVICE) as AudioManager }
+    private val mPlaybackAttributes by lazy {
+        AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
+    }
+    private val mFocusRequest: AudioFocusRequest by lazy {
+        AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+            .setFocusGain(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+            .setAudioAttributes(mPlaybackAttributes)
+            .setAcceptsDelayedFocusGain(false)
+            .setWillPauseWhenDucked(false)
+            .setOnAudioFocusChangeListener {}
+            .build()
+    }
 
     private val permissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
@@ -96,6 +114,26 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         permissionLauncher.launch(PERMISSIONS)
+        /*lifecycleScope.launch {
+            var searchUiState = com.example.deucapstone2023.ui.screen.search.state.Location.getInitValues()
+            var flag = false
+            launch {
+                searchViewModel.searchUiState.collect { state->
+                    searchUiState = state.location
+                    if(searchUiState.latitude != 0.0)
+                        flag = true
+                }
+            }
+            launch {
+                while(true) {
+                    while (flag) {
+                        searchViewModel::setUserLocation.invoke(searchUiState.latitude +0.00005000000000 , searchUiState.longitude - 0.00000500000000 )
+                        delay(5000)
+                    }
+                    delay(1000)
+                }
+            }
+        }*/
     }
 
     @SuppressLint("MissingPermission")
@@ -141,27 +179,31 @@ class MainActivity : ComponentActivity() {
             override fun onReceive(c: Context?, intent: Intent?) {
                 when (intent?.action) {
                     BluetoothDevice.ACTION_FOUND -> {
-                        if(!deviceHasFoundedFlag) {
+                        if (!deviceHasFoundedFlag) {
                             val device =
                                 intent.getParcelableExtra<BluetoothDevice>(BluetoothDevice.EXTRA_DEVICE)
-                            if(device?.name == DEVICE_NAME) {
-                                val remotedDevice = bluetoothAdapter?.getRemoteDevice(device.address)
+                            if (device?.name == DEVICE_NAME) {
+                                val remotedDevice =
+                                    bluetoothAdapter?.getRemoteDevice(device.address)
                                 connectBluetooth(remotedDevice)
                             }
                         }
                     }
+
                     BluetoothDevice.ACTION_ACL_CONNECTED -> {
                         voiceOutput("장치와 연결되었습니다.")
                         deviceHasFoundedFlag = true
                     }
+
                     BluetoothDevice.ACTION_ACL_DISCONNECTED -> {
                         voiceOutput("장치가 연결해제 되었습니다.")
                         deviceHasFoundedFlag = false
                         bluetoothAdapter?.startDiscovery()
                     }
+
                     BluetoothAdapter.ACTION_DISCOVERY_FINISHED -> {
-                        if(!deviceHasFoundedFlag) {
-                            if(settingViewModel.settingUiState.value.controlStatus.toBoolean())
+                        if (!deviceHasFoundedFlag) {
+                            if (settingViewModel.settingUiState.value.controlStatus.toBoolean())
                                 bluetoothAdapter?.startDiscovery()
                         }
                     }
@@ -215,11 +257,25 @@ class MainActivity : ComponentActivity() {
         bluetoothManager = this.getSystemService(BluetoothManager::class.java)
         bluetoothAdapter = bluetoothManager.adapter
 
-        startService(Intent(this, SpeechService::class.java))
+        //startService(Intent(this, SpeechService::class.java))
     }
 
     private fun voiceOutput(message: String) {
-        textToSpeech.speak(message, TextToSpeech.QUEUE_FLUSH, null, null)
+        lifecycleScope.launch(Dispatchers.Main) {
+            if(!textToSpeech.isSpeaking) {
+                val res =
+                    withContext(Dispatchers.Main) { audioManager.requestAudioFocus(mFocusRequest) }
+                when (res) {
+                    AudioManager.AUDIOFOCUS_REQUEST_FAILED -> {}
+                    AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> {
+                        textToSpeech.speak(message, TextToSpeech.QUEUE_FLUSH, null, null)
+                        checkIsSpeaking()
+                        audioManager.abandonAudioFocusRequest(mFocusRequest)
+                    }
+                }
+            }
+        }
+
         Log.d("tests", "msg: $message")
     }
 
@@ -270,6 +326,7 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
     private fun readOnBluetooth() {
         bluetoothSocket?.let { socket ->
             socket.inputStream.read(ByteArray(4096))

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/Search.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/Search.kt
@@ -21,9 +21,11 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,6 +43,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.withCreated
 import com.example.deucapstone2023.R
 import com.example.deucapstone2023.ui.base.CommonRecognitionListener
@@ -58,6 +61,7 @@ import com.skt.tmap.TMapView
 import com.skt.tmap.overlay.TMapMarkerItem
 import com.skt.tmap.overlay.TMapPolyLine
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 fun HomeScreen(
@@ -97,7 +101,7 @@ fun HomeScreen(
 
     val tMapGpsManager: TMapGpsManager = TMapGpsManager(context).apply {
         minTime = 7000
-        minDistance = 4.5F
+        minDistance = 5F
         provider = TMapGpsManager.PROVIDER_GPS
         setOnLocationChangeListener { location ->
             searchViewModel::setUserLocation.invoke(location.latitude, location.longitude)
@@ -181,10 +185,12 @@ private fun HomeScreen(
     val context = LocalContext.current
 
     LaunchedEffect(key1 = searchUiState.location) {
-        if (searchUiState.routeList.isNotEmpty())
+        if (searchUiState.routeList.isNotEmpty()) {
             navigateRouteOnMap { message ->
                 voiceOutput(message)
             }
+            setUserPosition(tMapView,searchUiState.location.latitude,searchUiState.location.longitude)
+        }
     }
 
     LaunchedEffect(key1 = searchEventFlow) {
@@ -209,6 +215,8 @@ private fun HomeScreen(
                     removeTMapPolyLine("pedestrianRoute")
                     addTMapPolyLine(polyLine)
                 }
+
+                voiceOutput("경로 안내를 시작합니다.")
             }
 
             is SearchEventFlow.POIList -> {
@@ -344,7 +352,7 @@ private fun PreviewHomeScreen() {
             navigateRouteOnMap = {},
             title = "",
             onTitleChanged = {},
-            onNavigateToNaviScreen = {},
+            onNavigateToNaviScreen = {}
         )
     }
 }

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/Search.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/Search.kt
@@ -202,8 +202,8 @@ fun HomeScreen(
                     locationPermissionRequest.launch(PERMISSIONS)
                 }
                 Lifecycle.Event.ON_RESUME -> {
-                    sensorManager.registerListener(sensorListener,accelerometerSensor,SensorManager.SENSOR_DELAY_UI)
-                    sensorManager.registerListener(sensorListener,magneticSensor,SensorManager.SENSOR_DELAY_UI)
+                    sensorManager.registerListener(sensorListener,accelerometerSensor,SensorManager.SENSOR_DELAY_NORMAL)
+                    sensorManager.registerListener(sensorListener,magneticSensor,SensorManager.SENSOR_DELAY_NORMAL)
                 }
                 Lifecycle.Event.ON_PAUSE -> {
                     sensorManager.unregisterListener(sensorListener)

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/SearchViewModel.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/SearchViewModel.kt
@@ -130,11 +130,11 @@ class SearchViewModel @Inject constructor(
             }
             else -> { // 목적지가 아니면, 현재 남은 거리 안내후 다음경로 안내
                 voiceOutput("${searchUiState.value.recentDistance}m 직진해 주세요. 이어서 ${searchUiState.value.routeList[searchUiState.value.routeIndex+1].description}해 주세요")
-                if(searchUiState.value.recentDistance <= 18)  // 이동한 거리가 12미터 초과 이고, 남은 거리가 12미터 미만 일 때
+                if(searchUiState.value.recentDistance <= 15)  // 이동한 거리가 12미터 초과 이고, 남은 거리가 12미터 미만 일 때
                     _searchUiState.update { state ->
                         state.copy(
                             routeIndex = state.routeIndex + 1,
-                            recentDistance = searchUiState.value.routeList[searchUiState.value.routeIndex + 1].totalDistance
+                            recentDistance = searchUiState.value.routeList[searchUiState.value.routeIndex + 1].totalDistance + searchUiState.value.recentDistance
                         )
                     }
             }

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/SearchViewModel.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/SearchViewModel.kt
@@ -79,18 +79,18 @@ class SearchViewModel @Inject constructor(
         navigationManager.destinationInfo = poi
     }
 
-    fun navigateRouteOnMap(azimuth:Double, voiceOutput: (String) -> Unit) {
+    fun navigateRouteOnMap(azimuth: Double, voiceOutput: (String) -> Unit) {
         navigationManager.navigateRouteOnMap(
             routeList = searchUiState.value.routeList,
             source = searchUiState.value.location,
             azimuth = getAzimuthFromValue(azimuth),
             voiceOutput = voiceOutput,
             quitNavigation = { _searchUiState.update { state -> state.copy(routeList = emptyList()) } },
-            requestPedestrianRoute = { requestPedestrianRoute(azimuth, voiceOutput) }
+            requestPedestrianRoute = { requestPedestrianRoute(voiceOutput) }
         )
     }
 
-    private fun requestPedestrianRoute(azimuth: Double, voiceOutput: (String) -> Unit) {
+    private fun requestPedestrianRoute(voiceOutput: (String) -> Unit) {
         getRoutePedestrian(appKey = context.getString(R.string.T_Map_key))
         voiceOutput("경로를 이탈 했습니다. 경로를 재 요청 합니다.")
     }
@@ -176,12 +176,17 @@ class SearchViewModel @Inject constructor(
                     routeList = route,
                 )
             }
-            navigationManager.recentDistance = route.first().totalDistance
-            navigationManager.routeIndex = 0
-            navigationManager.setInitAzimuth(
-                source = Location(route.first().startLatitude, route.first().startLongitude),
-                dest = Location(route.first().destinationLatitude, route.first().destinationLongitude)
-            )
+            navigationManager.apply {
+                recentDistance = route.first().totalDistance
+                routeIndex = 0
+                setInitAzimuth(
+                    source = Location(route.first().startLatitude, route.first().startLongitude),
+                    dest = Location(
+                        route.first().destinationLatitude,
+                        route.first().destinationLongitude
+                    )
+                )
+            }
 
         }.catchFetching(
             onFailedHttpException = { e ->

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/SearchViewModel.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/SearchViewModel.kt
@@ -84,7 +84,7 @@ class SearchViewModel @Inject constructor(
     fun navigateRouteOnMap(voiceOutput: (String) -> Unit) {
         val route = searchUiState.value.routeList[searchUiState.value.routeIndex]
 
-        if(searchUiState.value.recentDistance + 8 >= getDistanceFromHere(lat = route.destinationLatitude, lon = route.destinationLongitude)) {
+        if(searchUiState.value.recentDistance + 7 >= getDistanceFromHere(lat = route.destinationLatitude, lon = route.destinationLongitude)) {
             // 정상경로 -> LineString 정보를 활용 해서 현 위치 에서의 description 을 안내 해야함
             _searchUiState.update { state -> state.copy(recentDistance = getDistanceFromHere(lat = route.destinationLatitude, lon = route.destinationLongitude)) }
 
@@ -94,7 +94,7 @@ class SearchViewModel @Inject constructor(
                     voiceOutput("${route.description}해 주세요")
                 else {
                     //남은거리 안내
-                    if(searchUiState.value.recentDistance > 22) //18미터 초과라면 남은거리 안내
+                    if(searchUiState.value.recentDistance > 30) //18미터 초과라면 남은거리 안내
                         voiceOutput("보행자 경로를 따라 ${searchUiState.value.recentDistance}m 직진해 주세요")
                     else { // 남은 거리가 18미터 이하라면 다음경로 안내
                         guideRemainDistance(voiceOutput = voiceOutput)
@@ -104,7 +104,7 @@ class SearchViewModel @Inject constructor(
                 if(route.totalDistance - searchUiState.value.recentDistance <= 10) // 이동한 거리가 12미터 이하 일 때
                     voiceOutput("${route.description}해 주세요")
                 else {
-                    if(searchUiState.value.recentDistance > 22) { //이동한 거리가 12미터 초과 이고, 남은 거리가 18미터 초과일 때
+                    if(searchUiState.value.recentDistance > 30) { //이동한 거리가 12미터 초과 이고, 남은 거리가 18미터 초과일 때
                         voiceOutput("${searchUiState.value.recentDistance}m 직진해 주세요")
                     } else { //이동한 거리가 2미터 초과 이고, 남은 거리가 18미터 이하 일 때
                         guideRemainDistance(voiceOutput = voiceOutput)
@@ -121,7 +121,7 @@ class SearchViewModel @Inject constructor(
     private fun guideRemainDistance(voiceOutput : (String) -> Unit) {
         when(searchUiState.value.routeList[searchUiState.value.routeIndex + 1].pointType) {
             PointType.EP -> { // 목적지 라면, 목적지 안내
-                if(searchUiState.value.recentDistance <= 7) {
+                if(searchUiState.value.recentDistance <= 15) {
                     voiceOutput("목적지에 부근에 도착했습니다. 경로안내를 종료합니다.")
                     _searchUiState.update { state -> state.copy(routeList = emptyList()) }
                 } else {
@@ -130,7 +130,7 @@ class SearchViewModel @Inject constructor(
             }
             else -> { // 목적지가 아니면, 현재 남은 거리 안내후 다음경로 안내
                 voiceOutput("${searchUiState.value.recentDistance}m 직진해 주세요. 이어서 ${searchUiState.value.routeList[searchUiState.value.routeIndex+1].description}해 주세요")
-                if(searchUiState.value.recentDistance <= 10)  // 이동한 거리가 12미터 초과 이고, 남은 거리가 12미터 미만 일 때
+                if(searchUiState.value.recentDistance <= 18)  // 이동한 거리가 12미터 초과 이고, 남은 거리가 12미터 미만 일 때
                     _searchUiState.update { state ->
                         state.copy(
                             routeIndex = state.routeIndex + 1,

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/SearchViewModel.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/SearchViewModel.kt
@@ -8,12 +8,13 @@ import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.deucapstone2023.R
-import com.example.deucapstone2023.data.dto.response.poi.Poi
 import com.example.deucapstone2023.domain.model.POIModel
 import com.example.deucapstone2023.domain.usecase.POIUsecase
 import com.example.deucapstone2023.domain.usecase.RouteUsecase
 import com.example.deucapstone2023.ui.base.PointType
+import com.example.deucapstone2023.ui.base.getAzimuthFromValue
 import com.example.deucapstone2023.ui.screen.search.state.Location
+import com.example.deucapstone2023.ui.screen.search.state.NavigationManager
 import com.example.deucapstone2023.ui.screen.search.state.POIState
 import com.example.deucapstone2023.ui.screen.search.state.RouteState
 import com.example.deucapstone2023.ui.screen.search.state.toPOIListState
@@ -39,36 +40,17 @@ import javax.inject.Inject
 sealed class SearchEventFlow {
     object Loading : SearchEventFlow()
     data class POIList(val poiList: List<POIState>) : SearchEventFlow()
-    data class RouteList(val routeList: List<RouteState>) : SearchEventFlow()
 }
 
 @Stable
 data class SearchUiState(
     val location: Location,
-    val routeIndex: Int,
-    val recentDistance: Int,
-    val destinationInfo: POIState,
     val routeList: List<RouteState>
 ) {
-    fun getDistanceFromStart(lat: Double, lon: Double) =
-        MapUtils.getDistance(
-            TMapPoint(
-                location.latitude,
-                location.longitude
-            ),
-            TMapPoint(
-                lat,
-                lon
-            )
-        ).toInt()
-
     companion object {
         fun getInitValues(lat: Double = 35.15130665819491, lon: Double = 129.02657807928898) =
             SearchUiState(
                 location = Location(latitude = lat, longitude = lon),
-                routeIndex = 0,
-                recentDistance = 0,
-                destinationInfo = POIState.getInitValues(),
                 routeList = emptyList()
             )
     }
@@ -87,100 +69,28 @@ class SearchViewModel @Inject constructor(
     private val _searchUiState = MutableStateFlow(SearchUiState.getInitValues())
     val searchUiState get() = _searchUiState.asStateFlow()
 
+    private val navigationManager = NavigationManager()
+
     fun setUserLocation(lat: Double, lon: Double) = _searchUiState.update { state ->
         state.copy(location = Location(latitude = lat, longitude = lon))
     }
 
-    fun setDestinationInfo(poi: POIState) = _searchUiState.update { state ->
-        state.copy(destinationInfo = poi)
+    fun setDestinationInfo(poi: POIState) {
+        navigationManager.destinationInfo = poi
     }
 
-    fun navigateRouteOnMap(voiceOutput: (String) -> Unit) {
-        val route = searchUiState.value.routeList[searchUiState.value.routeIndex]
-
-        if (searchUiState.value.recentDistance + 7 >= searchUiState.value.getDistanceFromStart(lat = route.destinationLatitude, lon = route.destinationLongitude)) {
-            Log.d("test","이전거리 : ${searchUiState.value.recentDistance}, 남은거리 : ${searchUiState.value.getDistanceFromStart(lat = route.destinationLatitude, lon = route.destinationLongitude)}")
-            // 정상경로 -> LineString 정보를 활용 해서 현 위치 에서의 description 을 안내 해야함
-            _searchUiState.update { state ->
-                state.copy(
-                    recentDistance = searchUiState.value.getDistanceFromStart(
-                        lat = route.destinationLatitude,
-                        lon = route.destinationLongitude
-                    )
-                )
-            }
-
-            // point 없이 linestring이 이어서 결합된 경우 -> 지정 description 안내 후 남은 거리 만큼 이동 추가 안내
-            if (route.totalDistance != route.description.filter { it.isDigit() }.toInt()) {
-                if (route.description.filter { it.isDigit() }
-                        .toInt() > (route.totalDistance - searchUiState.value.recentDistance))
-                    when (route.pointType) {
-                        PointType.SP -> {
-                            voiceOutput("다음 안내시 까지 ${route.description.filter { it.isDigit() }}m 직진 해주세요.")
-                        }
-
-                        else -> voiceOutput("${route.name} 에서 ${route.turnType.desc} 후 다음 안내시 까지 직진 해주세요.")
-                    }
-                else {
-                    guideRemainDistance(voiceOutput)
-                }
-            } else { // point 와 linestring 이 1:1 매칭 인 경우
-                if (route.totalDistance - searchUiState.value.recentDistance <= 10) {// 이동한 거리가 10미터 이하 일 때
-                    when (route.pointType) {
-                        PointType.SP -> {
-                            voiceOutput("다음 안내시 까지 ${route.description.filter { it.isDigit() }}m 직진 해주세요.")
-                        }
-
-                        else -> voiceOutput("${route.name} 에서 ${route.turnType.desc} 후 다음 안내시 까지 직진 해주세요.")
-                    }
-                } else {
-                    guideRemainDistance(voiceOutput)
-                }
-            }
-        } else {
-            //경로 재요청
-            requestPedestrianRoute(voiceOutput = voiceOutput)
-            Toast.makeText(
-                context,
-                "total : ${searchUiState.value.recentDistance}, 거리: ${
-                    searchUiState.value.getDistanceFromStart(
-                        lat = route.destinationLatitude,
-                        lon = route.destinationLongitude
-                    )
-                }",
-                Toast.LENGTH_SHORT
-            ).show()
-        }
+    fun navigateRouteOnMap(azimuth:Double, voiceOutput: (String) -> Unit) {
+        navigationManager.navigateRouteOnMap(
+            routeList = searchUiState.value.routeList,
+            source = searchUiState.value.location,
+            azimuth = getAzimuthFromValue(azimuth),
+            voiceOutput = voiceOutput,
+            quitNavigation = { _searchUiState.update { state -> state.copy(routeList = emptyList()) } },
+            requestPedestrianRoute = { requestPedestrianRoute(azimuth, voiceOutput) }
+        )
     }
 
-    private fun guideRemainDistance(voiceOutput: (String) -> Unit) {
-        if (searchUiState.value.recentDistance <= 30) { // 남은 거리가 30미터 이하 이면, 안내
-            when (searchUiState.value.routeList[searchUiState.value.routeIndex + 1].pointType) {
-                PointType.EP -> { // 목적지 라면, 목적지 안내
-                    if (searchUiState.value.recentDistance <= 15) {
-                        voiceOutput("목적지에 부근에 도착했습니다. 경로안내를 종료합니다.")
-                        _searchUiState.update { state -> state.copy(routeList = emptyList()) }
-                    } else {
-                        voiceOutput("${searchUiState.value.recentDistance}m 직진해 주세요. 이어서 목적지가 있습니다.")
-                    }
-                }
-
-                else -> { // 목적지가 아니면, 현재 남은 거리 안내후 다음경로 안내
-                    voiceOutput("${searchUiState.value.recentDistance}m 직진해 주세요. 이어서 ${searchUiState.value.routeList[searchUiState.value.routeIndex + 1].description}해 주세요")
-                    if (searchUiState.value.recentDistance <= 15)  // 이동한 거리가 12미터 초과 이고, 남은 거리가 12미터 미만 일 때
-                        _searchUiState.update { state ->
-                            state.copy(
-                                routeIndex = state.routeIndex + 1,
-                                recentDistance = searchUiState.value.routeList[searchUiState.value.routeIndex + 1].totalDistance + searchUiState.value.recentDistance
-                            )
-                        }
-                }
-            }
-        }
-
-    }
-
-    private fun requestPedestrianRoute(voiceOutput: (String) -> Unit) {
+    private fun requestPedestrianRoute(azimuth: Double, voiceOutput: (String) -> Unit) {
         getRoutePedestrian(appKey = context.getString(R.string.T_Map_key))
         voiceOutput("경로를 이탈 했습니다. 경로를 재 요청 합니다.")
     }
@@ -256,22 +166,23 @@ class SearchViewModel @Inject constructor(
             appKey = appKey,
             startLatitude = searchUiState.value.location.latitude,
             startLongitude = searchUiState.value.location.longitude,
-            destinationPoiId = searchUiState.value.destinationInfo.id.toString(),
-            destinationLatitude = searchUiState.value.destinationInfo.latitude,
-            destinationLongitude = searchUiState.value.destinationInfo.longitude
+            destinationPoiId = navigationManager.destinationInfo.id.toString(),
+            destinationLatitude = navigationManager.destinationInfo.latitude,
+            destinationLongitude = navigationManager.destinationInfo.longitude
         ).onEach { routeModels ->
             val route = routeModels.toRouteListState()
             _searchUiState.update { state ->
                 state.copy(
                     routeList = route,
-                    recentDistance = route.first().totalDistance,
-                    routeIndex = 0
                 )
             }
-            emitEventFlow(
-                SearchEventFlow.RouteList(
-                    route.filter { it.lineInfo.isNotEmpty() })
+            navigationManager.recentDistance = route.first().totalDistance
+            navigationManager.routeIndex = 0
+            navigationManager.setInitAzimuth(
+                source = Location(route.first().startLatitude, route.first().startLongitude),
+                dest = Location(route.first().destinationLatitude, route.first().destinationLongitude)
             )
+
         }.catchFetching(
             onFailedHttpException = { e ->
                 Log.d("tests", "error : ${e.message}, ${e.printStackTrace()}}")

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/state/NavigationManager.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/state/NavigationManager.kt
@@ -1,0 +1,136 @@
+package com.example.deucapstone2023.ui.screen.search.state
+
+import com.example.deucapstone2023.ui.base.AzimuthType
+import com.example.deucapstone2023.ui.base.PointType
+import com.example.deucapstone2023.ui.base.getAzimuthFromValue
+import com.example.deucapstone2023.ui.base.toAzimuthType
+import com.skt.tmap.MapUtils
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+data class NavigationManager(
+    var routeIndex: Int,
+    var recentDistance: Int,
+    var destinationInfo: POIState,
+    var azimuth: AzimuthType
+) {
+    constructor() : this(
+        routeIndex = 0,
+        recentDistance = 0,
+        destinationInfo = POIState.getInitValues(),
+        azimuth = AzimuthType.SOUTH
+    )
+
+    private fun getDistanceFromSource(source: Location, dest: Location) =
+        MapUtils.getDistance(
+            source.latitude,
+            source.longitude,
+            dest.latitude,
+            dest.longitude
+        ).toInt()
+
+    fun setInitAzimuth(source: Location, dest: Location) {
+        val lat1 = source.latitude * Math.PI / 180
+        val lat2 = dest.latitude * Math.PI / 180
+        val lon1 = source.longitude * Math.PI / 180
+        val lon2 = dest.longitude * Math.PI / 180
+
+        val y = sin(lon2 - lon1) * cos(lat2)
+        val x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(lon2 - lon1)
+        val seta = atan2(y, x)
+        val bearing = (seta * 180 / Math.PI + 360) % 360
+        azimuth = getAzimuthFromValue(bearing)
+    }
+
+    fun navigateRouteOnMap(
+        routeList: List<RouteState>,
+        source: Location,
+        azimuth: AzimuthType,
+        voiceOutput: (String) -> Unit,
+        quitNavigation: () -> Unit,
+        requestPedestrianRoute: ((String) -> Unit) -> Unit
+    ) {
+        val route = routeList[routeIndex]
+        val halfPoint = route.totalDistance.div(2)
+
+        //TODO 현재 방위에 따라 다음 경로를 가기 위한 방위 안내 필요
+
+        if (recentDistance > getDistanceFromSource(
+                source = source,
+                dest = Location(route.destinationLatitude, route.destinationLongitude)
+            ) && recentDistance <= route.totalDistance && this.azimuth == azimuth
+        ) {
+            // 정상경로 -> LineString 정보를 활용 해서 현 위치 에서의 description 을 안내 해야함
+            recentDistance = getDistanceFromSource(
+                source = source,
+                dest = Location(route.destinationLatitude, route.destinationLongitude)
+            )
+
+            if (recentDistance >= halfPoint - 10 && recentDistance <= halfPoint + 10) {
+                guideRemainDistance(routeList = routeList,azimuth, voiceOutput, quitNavigation)
+            } else {
+                // point 없이 linestring이 이어서 결합된 경우 -> 지정 description 안내 후 남은 거리 만큼 이동 추가 안내
+                if (route.totalDistance != route.description.filter { it.isDigit() }.toInt()) {
+                    if (route.description.filter { it.isDigit() }
+                            .toInt() > (route.totalDistance - recentDistance))
+                        guideStartDistance(route, voiceOutput)
+                    else {
+                        if (recentDistance <= 30) { // 남은 거리가 30미터 이하 이면, 안내
+                            guideRemainDistance(routeList = routeList,azimuth, voiceOutput, quitNavigation)
+                        }
+                    }
+                } else { // point 와 linestring 이 1:1 매칭 인 경우
+                    if (route.totalDistance - recentDistance <= 10) {// 이동한 거리가 10미터 이하 일 때
+                        guideStartDistance(route, voiceOutput)
+                    } else {
+                        if (recentDistance <= 30) { // 남은 거리가 30미터 이하 이면, 안내
+                            guideRemainDistance(routeList = routeList,azimuth, voiceOutput, quitNavigation)
+                        }
+                    }
+                }
+            }
+        } else {
+            //경로 재요청
+            this.azimuth = azimuth
+            requestPedestrianRoute(voiceOutput)
+        }
+
+    }
+
+    private fun guideStartDistance(route: RouteState, voiceOutput: (String) -> Unit) {
+        when (route.pointType) {
+            PointType.SP -> {
+                voiceOutput("다음 안내시 까지 ${route.description.filter { it.isDigit() }}m 직진 해주세요.")
+            }
+
+            else -> voiceOutput("${route.name} 에서 ${route.turnType.desc} 후 다음 안내시 까지 직진 해주세요.")
+        }
+    }
+
+    private fun guideRemainDistance(
+        routeList: List<RouteState>,
+        currentAzimuthType: AzimuthType,
+        voiceOutput: (String) -> Unit,
+        quitNavigation: () -> Unit
+    ) {
+        when (routeList[routeIndex + 1].pointType) {
+            PointType.EP -> { // 목적지 라면, 목적지 안내
+                if (recentDistance <= 15) {
+                    voiceOutput("목적지에 부근에 도착했습니다. 경로안내를 종료합니다.")
+                    quitNavigation()
+                } else {
+                    voiceOutput("${recentDistance}m 직진해 주세요. 이어서 목적지가 있습니다.")
+                }
+            }
+
+            else -> { // 목적지가 아니면, 현재 남은 거리 안내후 다음경로 안내
+                voiceOutput("${recentDistance}m 직진해 주세요. 이어서 ${routeList[routeIndex + 1].description}해 주세요")
+                if (recentDistance <= 15) {// 남은 거리가 15미터 이하 이면, 다음 경로로 업데이트
+                    recentDistance = routeList[++routeIndex].totalDistance
+                    this.azimuth = routeList[routeIndex].turnType.toAzimuthType(currentAzimuthType)
+                }
+            }
+        }
+    }
+}

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/state/NavigationManager.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/state/NavigationManager.kt
@@ -54,8 +54,6 @@ data class NavigationManager(
         val route = routeList[routeIndex]
         val halfPoint = route.totalDistance.div(2)
 
-        //TODO 현재 방위에 따라 다음 경로를 가기 위한 방위 안내 필요
-
         if (recentDistance > getDistanceFromSource(
                 source = source,
                 dest = Location(route.destinationLatitude, route.destinationLongitude)
@@ -92,7 +90,6 @@ data class NavigationManager(
             }
         } else {
             //경로 재요청
-            this.azimuth = azimuth
             requestPedestrianRoute(voiceOutput)
         }
 

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/state/NavigationManager.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/state/NavigationManager.kt
@@ -1,47 +1,13 @@
 package com.example.deucapstone2023.ui.screen.search.state
 
+import android.content.Context
 import com.example.deucapstone2023.ui.base.AzimuthType
-import com.example.deucapstone2023.ui.base.PointType
-import com.example.deucapstone2023.ui.base.getAzimuthFromValue
-import com.example.deucapstone2023.ui.base.toAzimuthType
-import com.skt.tmap.MapUtils
-import kotlin.math.atan2
-import kotlin.math.cos
-import kotlin.math.sin
 
-data class NavigationManager(
-    var routeIndex: Int,
-    var recentDistance: Int,
-    var destinationInfo: POIState,
-    var azimuth: AzimuthType
-) {
-    constructor() : this(
-        routeIndex = 0,
-        recentDistance = 0,
-        destinationInfo = POIState.getInitValues(),
-        azimuth = AzimuthType.SOUTH
-    )
-
-    private fun getDistanceFromSource(source: Location, dest: Location) =
-        MapUtils.getDistance(
-            source.latitude,
-            source.longitude,
-            dest.latitude,
-            dest.longitude
-        ).toInt()
-
-    fun setInitAzimuth(source: Location, dest: Location) {
-        val lat1 = source.latitude * Math.PI / 180
-        val lat2 = dest.latitude * Math.PI / 180
-        val lon1 = source.longitude * Math.PI / 180
-        val lon2 = dest.longitude * Math.PI / 180
-
-        val y = sin(lon2 - lon1) * cos(lat2)
-        val x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(lon2 - lon1)
-        val seta = atan2(y, x)
-        val bearing = (seta * 180 / Math.PI + 360) % 360
-        azimuth = getAzimuthFromValue(bearing)
-    }
+interface NavigationManager {
+    var routeIndex: Int
+    var recentDistance: Int
+    var destinationInfo: POIState
+    var recentLineInfoIndex: Int
 
     fun navigateRouteOnMap(
         routeList: List<RouteState>,
@@ -49,85 +15,25 @@ data class NavigationManager(
         azimuth: AzimuthType,
         voiceOutput: (String) -> Unit,
         quitNavigation: () -> Unit,
-        requestPedestrianRoute: ((String) -> Unit) -> Unit
-    ) {
-        val route = routeList[routeIndex]
-        val halfPoint = route.totalDistance.div(2)
+        requestPedestrianRoute: ((String) -> Unit) -> Unit,
+        context: Context
+    )
 
-        if (recentDistance > getDistanceFromSource(
-                source = source,
-                dest = Location(route.destinationLatitude, route.destinationLongitude)
-            ) && recentDistance <= route.totalDistance && this.azimuth == azimuth
-        ) {
-            // 정상경로 -> LineString 정보를 활용 해서 현 위치 에서의 description 을 안내 해야함
-            recentDistance = getDistanceFromSource(
-                source = source,
-                dest = Location(route.destinationLatitude, route.destinationLongitude)
-            )
+    fun guideStartDistance(
+        route: RouteState,
+        voiceOutput: (String) -> Unit
+    )
 
-            if (recentDistance >= halfPoint - 10 && recentDistance <= halfPoint + 10) {
-                guideRemainDistance(routeList = routeList,azimuth, voiceOutput, quitNavigation)
-            } else {
-                // point 없이 linestring이 이어서 결합된 경우 -> 지정 description 안내 후 남은 거리 만큼 이동 추가 안내
-                if (route.totalDistance != route.description.filter { it.isDigit() }.toInt()) {
-                    if (route.description.filter { it.isDigit() }
-                            .toInt() > (route.totalDistance - recentDistance))
-                        guideStartDistance(route, voiceOutput)
-                    else {
-                        if (recentDistance <= 30) { // 남은 거리가 30미터 이하 이면, 안내
-                            guideRemainDistance(routeList = routeList,azimuth, voiceOutput, quitNavigation)
-                        }
-                    }
-                } else { // point 와 linestring 이 1:1 매칭 인 경우
-                    if (route.totalDistance - recentDistance <= 10) {// 이동한 거리가 10미터 이하 일 때
-                        guideStartDistance(route, voiceOutput)
-                    } else {
-                        if (recentDistance <= 30) { // 남은 거리가 30미터 이하 이면, 안내
-                            guideRemainDistance(routeList = routeList,azimuth, voiceOutput, quitNavigation)
-                        }
-                    }
-                }
-            }
-        } else {
-            //경로 재요청
-            requestPedestrianRoute(voiceOutput)
-        }
-
-    }
-
-    private fun guideStartDistance(route: RouteState, voiceOutput: (String) -> Unit) {
-        when (route.pointType) {
-            PointType.SP -> {
-                voiceOutput("다음 안내시 까지 ${route.description.filter { it.isDigit() }}m 직진 해주세요.")
-            }
-
-            else -> voiceOutput("${route.name} 에서 ${route.turnType.desc} 후 다음 안내시 까지 직진 해주세요.")
-        }
-    }
-
-    private fun guideRemainDistance(
+    fun guideRemainDistance(
         routeList: List<RouteState>,
-        currentAzimuthType: AzimuthType,
         voiceOutput: (String) -> Unit,
         quitNavigation: () -> Unit
-    ) {
-        when (routeList[routeIndex + 1].pointType) {
-            PointType.EP -> { // 목적지 라면, 목적지 안내
-                if (recentDistance <= 15) {
-                    voiceOutput("목적지에 부근에 도착했습니다. 경로안내를 종료합니다.")
-                    quitNavigation()
-                } else {
-                    voiceOutput("${recentDistance}m 직진해 주세요. 이어서 목적지가 있습니다.")
-                }
-            }
+    )
 
-            else -> { // 목적지가 아니면, 현재 남은 거리 안내후 다음경로 안내
-                voiceOutput("${recentDistance}m 직진해 주세요. 이어서 ${routeList[routeIndex + 1].description}해 주세요")
-                if (recentDistance <= 15) {// 남은 거리가 15미터 이하 이면, 다음 경로로 업데이트
-                    recentDistance = routeList[++routeIndex].totalDistance
-                    this.azimuth = routeList[routeIndex].turnType.toAzimuthType(currentAzimuthType)
-                }
-            }
-        }
-    }
+    fun getDistanceFromSource(source: Location, dest: Location): Int
+
+    fun calculateAzimuth(source: Location, dest: Location): Double
+
+    fun checkAzimuthDeviceWithLineInfo(azimuth: AzimuthType, route: RouteState): Boolean
+
 }

--- a/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/state/NavigationManagerImpl.kt
+++ b/DeuCapStone2023/app/src/main/java/com/example/deucapstone2023/ui/screen/search/state/NavigationManagerImpl.kt
@@ -1,0 +1,190 @@
+package com.example.deucapstone2023.ui.screen.search.state
+
+import android.content.Context
+import android.widget.Toast
+import com.example.deucapstone2023.ui.base.AzimuthType
+import com.example.deucapstone2023.ui.base.PointType
+import com.example.deucapstone2023.ui.base.getAzimuthFromValue
+import com.skt.tmap.MapUtils
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+class NavigationManagerImpl(
+    override var routeIndex: Int,
+    override var recentDistance: Int,
+    override var destinationInfo: POIState,
+    override var recentLineInfoIndex: Int
+) : NavigationManager {
+
+    constructor() : this(
+        routeIndex = 0,
+        recentDistance = 0,
+        destinationInfo = POIState.getInitValues(),
+        recentLineInfoIndex = 0
+    )
+
+    override fun getDistanceFromSource(source: Location, dest: Location): Int =
+        MapUtils.getDistance(
+            source.latitude,
+            source.longitude,
+            dest.latitude,
+            dest.longitude
+        ).toInt()
+
+    override fun calculateAzimuth(source: Location, dest: Location): Double {
+        val lat1 = source.latitude * Math.PI / 180
+        val lat2 = dest.latitude * Math.PI / 180
+        val lon1 = source.longitude * Math.PI / 180
+        val lon2 = dest.longitude * Math.PI / 180
+
+        val y = sin(lon2 - lon1) * cos(lat2)
+        val x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(lon2 - lon1)
+        val seta = atan2(y, x)
+        return (seta * 180 / Math.PI + 360) % 360
+    }
+
+    override fun checkAzimuthDeviceWithLineInfo(azimuth: AzimuthType, route: RouteState): Boolean =
+        azimuth == getAzimuthFromValue(
+            calculateAzimuth(
+                source = route.lineInfo[recentLineInfoIndex],
+                dest = route.lineInfo[recentLineInfoIndex + 1]
+            )
+        )
+
+    override fun navigateRouteOnMap(
+        routeList: List<RouteState>,
+        source: Location,
+        azimuth: AzimuthType,
+        voiceOutput: (String) -> Unit,
+        quitNavigation: () -> Unit,
+        requestPedestrianRoute: ((String) -> Unit) -> Unit,
+        context: Context
+    ) {
+        val route = routeList[routeIndex]
+        val halfPoint = route.totalDistance.div(2)
+
+        if (recentDistance - getDistanceFromSource(
+                source = source,
+                dest = Location(route.destinationLatitude, route.destinationLongitude)
+            ) < 10
+            && !checkAzimuthDeviceWithLineInfo(azimuth, route)
+        ) {
+            //경로 재요청
+            requestPedestrianRoute(voiceOutput)
+            Toast.makeText(
+                context, "a - device: $azimuth route: ${
+                    getAzimuthFromValue(
+                        calculateAzimuth(
+                            source = route.lineInfo[recentLineInfoIndex],
+                            dest = route.lineInfo[recentLineInfoIndex + 1]
+                        )
+                    )
+                }, index: $recentLineInfoIndex", Toast.LENGTH_LONG
+            ).show()
+        } else {
+            if (recentDistance > getDistanceFromSource(
+                    source = source,
+                    dest = Location(route.destinationLatitude, route.destinationLongitude)
+                ) && recentDistance <= route.totalDistance
+            ) {
+                // 정상경로 -> LineString 정보를 활용 해서 현 위치 에서의 description 을 안내 해야함
+                recentDistance = getDistanceFromSource(
+                    source = source,
+                    dest = Location(route.destinationLatitude, route.destinationLongitude)
+                )
+
+                if (recentDistance >= halfPoint - 10 && recentDistance <= halfPoint + 10) {
+                    guideRemainDistance(routeList = routeList, voiceOutput, quitNavigation)
+                } else {
+                    // point 없이 linestring이 이어서 결합된 경우 -> 지정 description 안내 후 남은 거리 만큼 이동 추가 안내
+                    if (route.totalDistance != route.description.filter { it.isDigit() }.toInt()) {
+                        if (route.description.filter { it.isDigit() }
+                                .toInt() > route.totalDistance - recentDistance
+                            && route.totalDistance - recentDistance >= 5
+                        )
+                            guideStartDistance(route, voiceOutput)
+                        else {
+                            if (recentDistance <= 30) { // 남은 거리가 30미터 이하 이면, 안내
+                                guideRemainDistance(
+                                    routeList = routeList,
+                                    voiceOutput,
+                                    quitNavigation
+                                )
+                            }
+                        }
+                    } else { // point 와 linestring 이 1:1 매칭 인 경우
+                        if (route.totalDistance - recentDistance in 5..15) {// 이동한 거리가 10미터 이하 일 때
+                            guideStartDistance(route, voiceOutput)
+                        } else {
+                            if (recentDistance <= 30) { // 남은 거리가 30미터 이하 이면, 안내
+                                guideRemainDistance(
+                                    routeList = routeList,
+                                    voiceOutput,
+                                    quitNavigation
+                                )
+                            }
+                        }
+                    }
+                    //정상경로 -> 10미터 단위로 gps가 바뀌기 때문에, lineString의 다음 좌표로 변경시킴
+                    if (getDistanceFromSource(
+                            source = source,
+                            dest = route.lineInfo[recentLineInfoIndex + 1]
+                        ) <= 10
+                    )
+                        recentLineInfoIndex++
+                }
+            } else {
+                //경로 재요청
+                requestPedestrianRoute(voiceOutput)
+                Toast.makeText(
+                    context, "total: ${route.totalDistance}, remain: $recentDistance, actual: ${
+                        getDistanceFromSource(
+                            source = source,
+                            dest = Location(route.destinationLatitude, route.destinationLongitude)
+                        )
+                    }", Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+
+    }
+
+    override fun guideStartDistance(
+        route: RouteState,
+        voiceOutput: (String) -> Unit
+    ) {
+        when (route.pointType) {
+            PointType.SP -> {
+                voiceOutput("다음 안내시 까지 ${route.description.filter { it.isDigit() }}m 직진 해주세요.")
+            }
+
+            else -> voiceOutput("${route.name} 에서 ${route.turnType.desc} 후 다음 안내시 까지 직진 해주세요.")
+        }
+    }
+
+    override fun guideRemainDistance(
+        routeList: List<RouteState>,
+        voiceOutput: (String) -> Unit,
+        quitNavigation: () -> Unit
+    ) {
+        when (routeList[routeIndex + 1].pointType) {
+            PointType.EP -> { // 목적지 라면, 목적지 안내
+                if (recentDistance <= 15) {
+                    voiceOutput("목적지에 부근에 도착했습니다. 경로안내를 종료합니다.")
+                    quitNavigation()
+                } else {
+                    voiceOutput("${recentDistance}m 직진해 주세요. 이어서 목적지가 있습니다.")
+                }
+            }
+
+            else -> { // 목적지가 아니면, 현재 남은 거리 안내후 다음경로 안내
+                voiceOutput("${recentDistance}m 직진해 주세요. 이어서 ${routeList[routeIndex + 1].description}해 주세요")
+                if (recentDistance <= 15) {// 남은 거리가 15미터 이하 이면, 다음 경로로 업데이트
+                    recentDistance = routeList[++routeIndex].totalDistance
+                    recentLineInfoIndex = 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 네비게이션 알고리즘 수정함.
1. 이동한 거리가 10미터 미만이면서, 기기의 방위와 실제 거리사이의 방위가 달랐는가?
2. 그렇지 않다면, 이동한 거리가 감소하고 있으며 전체 남은 거리보다 작은가?
3. 그렇다면, 경로안내
4. 그렇지 않다면 경로 재요청

 - 네비게이션 매니저클래스를 인터페이스로 분리하고 의존성 역전(DIP)로 결합도 낮춤. 향후 자동차 네비게이션의 확장성을 염두함

 - 위치센서를 tMapGpsManager 에서 fusedLocationProviderClient 로 변경

 - 자이드로센서와 가속도센서 값을 받아와서 네비게이션 로직에 방위정보를 사용하도록 변경함

 - 데이터에서 totalDistance가 0일때가 존재해서 거리계산해서 할당하도록 수정

 - 경로안내를 지속적으로 하지않고, 처음-중간-마지막 에 안내하도록 변경

 - 위치이동시 마크 이동하도록 변경

 - TTS 중에 오디오 포커싱을 pause 하지 않고 ducking 하도록 변경